### PR TITLE
Fix script to work with newer versions of GNU Make documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 	rm -rf $(DOCSET_DIR) $(ARCHIVE_FILE)
 
 tmp:
-	mkdir $@
+	mkdir -p $@
 
 $(ARCHIVE_FILE): $(DOCSET)
 	tar --exclude='.DS_Store' -czf $@ $(DOCSET_DIR)
@@ -32,16 +32,16 @@ $(MANUAL_FILE): tmp
 	curl -o $@ $(MANUAL_URL)
 
 $(DOCSET_DIR):
-	mkdir $@
+	mkdir -p $@
 
 $(CONTENTS_DIR): $(DOCSET_DIR)
-	mkdir $@
+	mkdir -p $@
 
 $(RESOURCES_DIR): $(CONTENTS_DIR)
-	mkdir $@
+	mkdir -p $@
 
 $(DOCUMENTS_DIR): $(RESOURCES_DIR) $(MANUAL_FILE)
-	mkdir $@
+	mkdir -p $@
 	tar -x -z -f $(MANUAL_FILE) -C $@
 
 $(INFO_PLIST_FILE): src/Info.plist $(CONTENTS_DIR)

--- a/src/index.rb
+++ b/src/index.rb
@@ -9,7 +9,7 @@ INSERT_SQL = %Q[
   INSERT INTO searchIndex(name, type, path) VALUES ('%s','%s','%s');
 ]
 
-PATTERN = %r[<title>GNU make: (.+)</title>]
+PATTERN = %r[<title>(.*)\(GNU make\)(.*)</title>]
 
 def quote(s)
   s.gsub(/&amp;/, '&').gsub(/'/, "\\'")


### PR DESCRIPTION
- Change `PATTERN` to work with newer versions of GNU Make documentation
    - The old pattern would fail for each file when testing with GNU Make documentation version 0.76 (for GNU Make 4.4)
- Replaced `mkdir` with `mkdir -p` in `Makefile` to avoid having to do a `make clean` each time