### PR TITLE
Newer document titles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 	rm -rf $(DOCSET_DIR) $(ARCHIVE_FILE)
 
 tmp:
-	mkdir $@
+	mkdir -p $@
 
 $(ARCHIVE_FILE): $(DOCSET)
 	tar --exclude='.DS_Store' -czf $@ $(DOCSET_DIR)
@@ -32,16 +32,16 @@ $(MANUAL_FILE): tmp
 	curl -o $@ $(MANUAL_URL)
 
 $(DOCSET_DIR):
-	mkdir $@
+	mkdir -p $@
 
 $(CONTENTS_DIR): $(DOCSET_DIR)
-	mkdir $@
+	mkdir -p $@
 
 $(RESOURCES_DIR): $(CONTENTS_DIR)
-	mkdir $@
+	mkdir -p $@
 
 $(DOCUMENTS_DIR): $(RESOURCES_DIR) $(MANUAL_FILE)
-	mkdir $@
+	mkdir -p $@
 	tar -x -z -f $(MANUAL_FILE) -C $@
 
 $(INFO_PLIST_FILE): src/Info.plist $(CONTENTS_DIR)

--- a/src/index.rb
+++ b/src/index.rb
@@ -21,7 +21,7 @@ ARGV.each do |arg|
     if match
       printf INSERT_SQL, quote(match[1]), 'Guide', path.basename
     else
-      $stderr.puts "%{path.basename}: no title found"
+      $stderr.puts "#{path}: no title found"
     end
   end
 end

--- a/src/index.rb
+++ b/src/index.rb
@@ -9,7 +9,7 @@ INSERT_SQL = %Q[
   INSERT INTO searchIndex(name, type, path) VALUES ('%s','%s','%s');
 ]
 
-PATTERN = %r[<title>GNU make: (.+)</title>]
+PATTERN = %r[<title>(.+)</title>]
 
 def quote(s)
   s.gsub(/&amp;/, '&').gsub(/'/, "\\'")
@@ -19,7 +19,10 @@ ARGV.each do |arg|
   Pathname.glob(arg) do |path|
     match = path.each_line.lazy.map { |line| PATTERN.match(line) }.find { |m| m }
     if match
-      printf INSERT_SQL, quote(match[1]), 'Guide', path.basename
+      title = match[1]
+      title.delete_prefix!('GNU make: ') # older docs
+      title.delete_suffix!(' (GNU make)') # newer docs
+      printf INSERT_SQL, quote(title), 'Guide', path.basename
     else
       $stderr.puts "#{path}: no title found"
     end


### PR DESCRIPTION
The GNU make project changed their documentation so that instead of titles like this:

> GNU make: Archiving

they now have titles like this:

> Archiving (GNU make)

This change supports both formats and is also less likely to completely break if the format changes again in the future.

Based upon https://github.com/benzado/gnu-make-dash-docset/pull/2

Hey @lshprung can you give me a 👍 or 👎 on this PR?